### PR TITLE
adds sysfs interfaces that allows charging while in otg

### DIFF
--- a/drivers/battery/sec_battery.c
+++ b/drivers/battery/sec_battery.c
@@ -6599,6 +6599,8 @@ static int sec_bat_cable_check(struct sec_battery_info *battery,
 		battery->store_mode |= STORE_MODE_RDU_TA;
 	case ATTACHED_DEV_TA_MUIC:
 	case ATTACHED_DEV_CARDOCK_MUIC:
+	// enable charging from audiodock
+	case ATTACHED_DEV_AUDIODOCK_MUIC:
 	case ATTACHED_DEV_DESKDOCK_VB_MUIC:
 	case ATTACHED_DEV_SMARTDOCK_TA_MUIC:
 	case ATTACHED_DEV_UNOFFICIAL_TA_MUIC:

--- a/drivers/battery_v2/sec_battery.c
+++ b/drivers/battery_v2/sec_battery.c
@@ -6808,6 +6808,8 @@ static int sec_bat_cable_check(struct sec_battery_info *battery,
 	case ATTACHED_DEV_RDU_TA_MUIC:
 		battery->store_mode = true;
 	case ATTACHED_DEV_TA_MUIC:
+	// enable charging from audiodock
+	case ATTACHED_DEV_AUDIODOCK_MUIC:
 	case ATTACHED_DEV_CARDOCK_MUIC:
 	case ATTACHED_DEV_DESKDOCK_VB_MUIC:
 	case ATTACHED_DEV_SMARTDOCK_TA_MUIC:

--- a/drivers/muic/universal/muic-internal.h
+++ b/drivers/muic/universal/muic-internal.h
@@ -214,6 +214,8 @@ typedef struct _muic_data_t {
 	int			is_ccic_afc_enable;
 	int			is_ccic_rp56_enable;
 #endif
+	// audiodock hack
+	bool otg_is_audiodock;
 }muic_data_t;
 
 extern struct device *switch_device;

--- a/drivers/muic/universal/muic_sysfs.c
+++ b/drivers/muic/universal/muic_sysfs.c
@@ -55,6 +55,8 @@
 #include "muic_ccic.h"
 #endif
 
+#include "muic_vps.h"
+
 static int muic_resolve_attached_dev(muic_data_t *pmuic)
 {
 #if defined(CONFIG_MUIC_SUPPORT_CCIC)
@@ -241,6 +243,46 @@ static ssize_t muic_show_usb_state(struct device *dev,
 	}
 
 	return 0;
+}
+
+static ssize_t muic_show_force_enable_audiodock(struct device *dev,
+					   struct device_attribute *pattr,
+					   char *buf){
+	int val = vps_is_supported_dev(ATTACHED_DEV_AUDIODOCK_MUIC);
+	return sprintf(buf, "%d\n", val);
+}
+
+static ssize_t muic_set_force_enable_audiodock(struct device *dev,
+		struct device_attribute *pattr,
+		const char *buf, size_t count){
+	bool enable;
+	if(!strncmp(buf, "0", 1)){
+		enable = 0;
+	}else{
+		enable = 1;
+	}
+	vps_update_supported_attr(ATTACHED_DEV_AUDIODOCK_MUIC, enable);
+	return count;
+}
+
+static ssize_t muic_show_force_otg_audiodock(struct device *dev,
+					   struct device_attribute *pattr,
+					   char *buf){
+	muic_data_t *pmuic = dev_get_drvdata(dev);
+	int val = pmuic->otg_is_audiodock;
+	return sprintf(buf, "%d\n", val);
+}
+
+static ssize_t muic_set_force_otg_audiodock(struct device *dev,
+		struct device_attribute *pattr,
+		const char *buf, size_t count){
+	muic_data_t *pmuic = dev_get_drvdata(dev);
+	if(!strncmp(buf, "0", 1)){
+		pmuic->otg_is_audiodock = 0;
+	}else{
+		pmuic->otg_is_audiodock = 1;
+	}
+	return count;
 }
 
 #if defined(CONFIG_USB_HOST_NOTIFY)
@@ -598,6 +640,10 @@ static DEVICE_ATTR(usb_state, 0664, muic_show_usb_state, NULL);
 static DEVICE_ATTR(otg_test, 0664,
 		muic_show_otg_test, muic_set_otg_test);
 #endif
+static DEVICE_ATTR(force_enable_audiodock, 0664,
+		muic_show_force_enable_audiodock, muic_set_force_enable_audiodock);
+static DEVICE_ATTR(force_otg_audiodock, 0664,
+		muic_show_force_otg_audiodock, muic_set_force_otg_audiodock);
 static DEVICE_ATTR(attached_dev, 0664, muic_show_attached_dev, NULL);
 static DEVICE_ATTR(audio_path, 0664,
 		muic_show_audio_path, muic_set_audio_path);
@@ -624,6 +670,8 @@ static struct attribute *muic_attributes[] = {
 	&dev_attr_usb_sel.attr,
 	&dev_attr_adc.attr,
 	&dev_attr_usb_state.attr,
+	&dev_attr_force_enable_audiodock.attr,
+	&dev_attr_force_otg_audiodock.attr,
 #if defined(CONFIG_USB_HOST_NOTIFY)
 	&dev_attr_otg_test.attr,
 #endif

--- a/drivers/muic/universal/muic_vps.c
+++ b/drivers/muic/universal/muic_vps.c
@@ -524,6 +524,12 @@ int vps_find_attached_dev(muic_data_t *pmuic, muic_attached_dev_t *pdev, int *pi
 
 		new_dev = chgdet_dev ? chgdet_dev : mdev;
 
+		// audiodock hack
+		if(pmuic->otg_is_audiodock && new_dev == MDEV(OTG)){
+			pr_info("%s:otg is forced to be audiodock instead.\n", __func__);
+			mdev = new_dev = MDEV(AUDIODOCK);
+		}
+
 		break;
 	}
 


### PR DESCRIPTION
During the galaxy s3 days samsung sold an "audiodock" with the model number EDD-D200BEGSTA, it very likely houses an audio card that would only power from micro usb connected to the dock. It IDs itself with a 64.9K ohm resister on id pin, and once a samsung device detects it, it will go into a special dock mode where usb data pins are in host mode, but vbus would stay as a client device, effectively "otg while charging".

I'm a little scared of this however, because I don't know why samsung disabled the audiodock in dts (same for s6, driver support is there but disabled in dts).

To enable audiodock (id - 64.9K ohm - gnd):
echo 1 > /sys/devices/virtual/sec/switch/force_enable_audiodock

Other than that, this commit also allows one to spoof normal otg as audiodock. That would allow an OTG cable with an active vbus but without a resister mod to provide charging to the device with otg enabled. The active vbus would also be powering client devices.

To enable otg audiodock spoofing:
echo 1 > /sys/devices/virtual/sec/switch/force_otg_audiodock